### PR TITLE
Fix manylinux image

### DIFF
--- a/.github/workflows/regression_suite.yaml
+++ b/.github/workflows/regression_suite.yaml
@@ -14,13 +14,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         include:
           # Windows wheels are release-critical but broke silently in 0.0.219 (3.13) and
           # were dropped entirely in 0.0.233. Build and test on Windows here so a broken
           # MSVC build fails in CI rather than at release time.
           - os: windows-latest
-            python-version: '3.9'
+            python-version: '3.10'
           - os: windows-latest
             python-version: '3.13'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     runs-on: ubuntu-latest
     env:
       # manylinux2014 (glibc 2.17) is no longer buildable: numpy dropped
@@ -69,7 +69,6 @@ jobs:
       max-parallel: 4
       matrix:
         include:
-          - python-version: '3.9'
           - python-version: '3.10'
           - python-version: '3.11'
           - python-version: '3.12'
@@ -111,7 +110,6 @@ jobs:
       max-parallel: 4
       matrix:
         include:
-          - python-version: '3.9'
           - python-version: '3.10'
           - python-version: '3.11'
           - python-version: '3.12'
@@ -198,7 +196,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,26 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - python-version: '3.9'
-            manylinux_image: 'quay.io/pypa/manylinux2014_x86_64'
-            plat: 'manylinux2014_x86_64'
-          - python-version: '3.10'
-            manylinux_image: 'quay.io/pypa/manylinux2014_x86_64'
-            plat: 'manylinux2014_x86_64'
-          - python-version: '3.11'
-            manylinux_image: 'quay.io/pypa/manylinux2014_x86_64'
-            plat: 'manylinux2014_x86_64'
-          - python-version: '3.12'
-            manylinux_image: 'quay.io/pypa/manylinux2014_x86_64'
-            plat: 'manylinux2014_x86_64'
-          - python-version: '3.13'
-            manylinux_image: 'quay.io/pypa/manylinux2014_x86_64'
-            plat: 'manylinux2014_x86_64'
-          - python-version: '3.14'
-            manylinux_image: 'quay.io/pypa/manylinux2014_x86_64'
-            plat: 'manylinux2014_x86_64'
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     runs-on: ubuntu-latest
+    env:
+      # manylinux2014 (glibc 2.17) is no longer buildable: numpy dropped
+      # manylinux_2_17 wheels at 2.3.0, so pip fell back to the sdist and failed
+      # against the image's GCC 10.2.1 ("NumPy requires GCC >= 10.3"). Moving to
+      # glibc 2.28 loses nothing real - pyarrow and numpy are hard runtime
+      # requirements of orso and both ship manylinux_2_28 only, so a glibc 2.17
+      # wheel could not have been installed anyway.
+      MANYLINUX_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
+      PLAT: manylinux_2_28_x86_64
     steps:
       - name: Set up Python (runner)
         uses: actions/setup-python@v4
@@ -52,30 +43,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          DESIRED_IMAGE="${{ matrix.manylinux_image }}"
-          echo "Attempting to pull ${DESIRED_IMAGE}..."
+          echo "Pulling ${MANYLINUX_IMAGE}..."
+          docker pull "${MANYLINUX_IMAGE}"
 
-          if docker pull "${DESIRED_IMAGE}" 2>/dev/null; then
-            IMAGE="${DESIRED_IMAGE}"
-          else
-            echo "Failed to pull ${DESIRED_IMAGE}; trying fallback..."
-            if docker pull quay.io/pypa/manylinux2014_x86_64 2>/dev/null; then
-              IMAGE=quay.io/pypa/manylinux2014_x86_64
-            else
-              echo "ERROR: no manylinux image available. Tried: ${DESIRED_IMAGE}, quay.io/pypa/manylinux2014_x86_64"
-              exit 125
-            fi
-          fi
-
-          echo "Using container image: ${IMAGE} with PLAT=${{ matrix.plat }}"
-
+          echo "Building with ${MANYLINUX_IMAGE} (PLAT=${PLAT})"
           docker run --rm \
-            -e PLAT=${{ matrix.plat }} \
+            -e PLAT="${PLAT}" \
             -e PACKAGE_NAME=orso \
             -e PYTHON_VERSION=${{ matrix.python-version }} \
             -v `pwd`:/io \
             --workdir /io \
-            "${IMAGE}" \
+            "${MANYLINUX_IMAGE}" \
             io/build.sh
 
       - name: Archive Wheels
@@ -83,6 +61,7 @@ jobs:
         with:
           name: dist-linux-${{ matrix.python-version }}
           path: io/dist/*manylinux*.whl
+          if-no-files-found: error
 
   build-macos:
     runs-on: macos-latest
@@ -123,6 +102,7 @@ jobs:
         with:
           name: dist-macos-${{ matrix.python-version }}
           path: dist
+          if-no-files-found: error
 
   build-windows:
     runs-on: windows-latest

--- a/orso/version.py
+++ b/orso/version.py
@@ -10,5 +10,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "0.0.244"
+__version__: str = "0.0.246"
 __author__: str = "@joocer"

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,9 @@ setup_config = {
     "url": "https://github.com/mabel-dev/orso/",
     "ext_modules": cythonize(extensions),
     "install_requires": required,
+    # 3.9 is EOL (Oct 2025) and our own dependencies no longer publish cp39
+    # wheels; without this pip would offer 3.9 users an sdist they cannot use.
+    "python_requires": ">=3.10",
     "extras_require": {
         # pysimdjson provides the `simdjson` Python module used as an optional accelerator.
         "simdjson": ["pysimdjson"],


### PR DESCRIPTION
This pull request updates the project's supported Python versions, removes Python 3.9 from all build and test workflows, and upgrades the manylinux build image to address compatibility issues with dependencies. It also bumps the package version and sets the minimum required Python version to 3.10.

**Python version support updates:**

* Dropped Python 3.9 from all CI jobs and build matrices in `.github/workflows/release.yaml` and `.github/workflows/regression_suite.yaml`, so only Python 3.10+ are now supported and tested. [[1]](diffhunk://#diff-ef566ec67de8ac5d5e39e0025b04b9d7ceef2fad848c8d3a8a6f95cf177b7f54L17-R23) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL17-R27) [[3]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL134)
* Updated `setup.py` to require Python >=3.10, preventing installation on unsupported versions.

**Build system improvements:**

* Switched the manylinux image from `manylinux2014` (glibc 2.17) to `manylinux_2_28` (glibc 2.28) in the release workflow, due to dependency requirements (e.g., numpy and pyarrow no longer supporting glibc 2.17). Simplified the Docker image selection logic accordingly. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL17-R27) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL55-L93)
* Updated the Linux and macOS wheel archiving steps to fail if no files are found, improving CI reliability. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL55-L93) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR104)

**Version bump:**

* Incremented the package version in `orso/version.py` from 0.0.244 to 0.0.246.